### PR TITLE
Attempt to fix newline database issue

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -25,7 +25,7 @@ local function setup(args)
                             BashExec = [===[
                             PTH=$(basename "${XPLR_FOCUS_PATH:?}")
                             DEST="]===] .. args.db_path .. [===["
-                            curl --data-binary "@${PTH:?}" "https://paste.rs" | tee -a "${DEST:?}"
+                            curl --data-binary "@${PTH:?}" "https://paste.rs" -w "\n" | tee -a "${DEST:?}"
                             echo
                             read -p "[enter to continue]"
                             ]===],


### PR DESCRIPTION
In the current code, no newlines are appended between entries, so working with `fzf` will not give you separate entries on each line.

Awesome tool, though!